### PR TITLE
disable scheduled workflows

### DIFF
--- a/.github/workflows/certificate-expiry-check.yml
+++ b/.github/workflows/certificate-expiry-check.yml
@@ -1,8 +1,9 @@
 name: Certificate Expiry
 
 on:
-  schedule:
-    - cron: '0 9 * * *'
+  workflow_dispatch:
+  # schedule:
+   # - cron: '0 9 * * *'
 
 jobs:
   certificate-expiry-check:

--- a/.github/workflows/certificate-expiry-undeliverable-report.yml
+++ b/.github/workflows/certificate-expiry-undeliverable-report.yml
@@ -1,8 +1,9 @@
 name: Certificate Expiry Undeliverable Report
 
 on:
-  schedule:
-    - cron: '10 9 * * *'
+  workflow_dispatch:
+  # schedule:
+    # - cron: '10 9 * * *'
 
 jobs:
   certificate-expiry-check:


### PR DESCRIPTION
PR to disable scheduled workflows as they were migrated to https://github.com/ministryofjustice/operations-engineering